### PR TITLE
RRL in proxy mode

### DIFF
--- a/src/knot/server/rrl.c
+++ b/src/knot/server/rrl.c
@@ -143,6 +143,8 @@ static int rrl_clsname(char *dst, size_t maxlen, uint8_t cls,
 	/* Found associated zone. */
 	if (zone != NULL) {
 		dn = zone->name;
+	} else if (req->name != NULL) {
+		dn = req->name;
 	}
 
 	switch (cls) {

--- a/src/knot/server/rrl.h
+++ b/src/knot/server/rrl.h
@@ -86,6 +86,7 @@ typedef struct rrl_req {
 	uint16_t len;
 	unsigned flags;
 	knot_pkt_t *query;
+	const knot_dname_t *name;
 } rrl_req_t;
 
 /*!


### PR DESCRIPTION
Get the zone cut from either the signer name, soa owner name or ns owner name.

Notes:
- To do: if the zone cut is deduced from a RRSIG record, we could also detect if there was a wildcard match and set the RRL_WILDCARD flag.
- Perhaps only the name needs to be retrieved from the SOA record in case of a NXDOMAIN, since RRL will use the query name anyway for the other classifications.