### PR TITLE
Partial async conversion

### DIFF
--- a/src/contrib/net.c
+++ b/src/contrib/net.c
@@ -535,6 +535,20 @@ ssize_t net_stream_recv(int sock, uint8_t *buffer, size_t size, int timeout_ms)
 	return net_recv(sock, buffer, size, NULL, timeout_ms);
 }
 
+ssize_t net_send_nonblocking(int sock, struct msghdr *msg)
+{
+	ssize_t len = sendmsg(sock, msg, MSG_NOSIGNAL);
+	if (len > 0) msg_iov_shift(msg, len);
+	return len;
+}
+
+ssize_t net_recv_nonblocking(int sock, struct msghdr *msg)
+{
+	ssize_t len = recvmsg(sock, msg, MSG_DONTWAIT | MSG_NOSIGNAL);
+	if (len > 0) msg_iov_shift(msg, len);
+	return len;
+}
+
 /* -- DNS specific I/O ----------------------------------------------------- */
 
 ssize_t net_dns_tcp_send(int sock, const uint8_t *buffer, size_t size, int timeout_ms)

--- a/src/contrib/net.h
+++ b/src/contrib/net.h
@@ -163,6 +163,26 @@ ssize_t net_stream_send(int sock, const uint8_t *buffer, size_t size, int timeou
 ssize_t net_stream_recv(int sock, uint8_t *buffer, size_t size, int timeout_ms);
 
 /*!
+ * \brief Send a message without blocking.
+ *
+ * The sent data is shifted out of msg.  If there is any data remaining in msg
+ * then this function should be reinvoked when sock is ready for writing.
+ *
+ * \see net_send
+ */
+ssize_t net_send_nonblocking(int sock, struct msghdr *msg);
+
+/*!
+ * \brief Receive a message without blocking.
+ *
+ * The received data is shifted out of msg.  If there is any space remaining in
+ * msg then this function should be reinvoked when sock is ready for reading.
+ *
+ * \see net_recv
+ */
+ssize_t net_recv_nonblocking(int sock, struct msghdr *msg);
+
+/*!
  * \brief Send a DNS message on a TCP socket.
  *
  * The outgoing message is prefixed with a two-byte value carrying the DNS

--- a/src/knot/modules/dnsproxy.c
+++ b/src/knot/modules/dnsproxy.c
@@ -65,7 +65,7 @@ static int dnsproxy_fwd(int state, knot_pkt_t *pkt, struct query_data *qdata, vo
 	struct dnsproxy *proxy = ctx;
 	struct dnsproxy_data *proxy_data = layer->defer_data;
 
-	if (proxy_data == NULL) {
+	if (layer->defer_fd.fd == 0) {
 		if (pkt == NULL || qdata == NULL || ctx == NULL) {
 			return KNOT_STATE_FAIL;
 		}
@@ -104,7 +104,7 @@ static int dnsproxy_fwd(int state, knot_pkt_t *pkt, struct query_data *qdata, vo
 		}
 
 		layer->defer_data = proxy_data;
-	} else if (layer->defer_fd.fd == 0 || layer->defer_timeout == -1) {
+	} else if (layer->defer_fd.fd == -1 || layer->defer_timeout == -1) {
 		// The request is being cancelled.  We need to clean up.
 		layer->defer_fd.fd = 0;
 		proxy_data->re.mm = qdata->mm;

--- a/src/knot/modules/dnsproxy.c
+++ b/src/knot/modules/dnsproxy.c
@@ -83,13 +83,10 @@ static int dnsproxy_fwd(int state, knot_pkt_t *pkt, struct query_data *qdata, vo
 
 		/* Capture layer context. */
 		const knot_layer_api_t *capture = query_capture_api();
-		struct capture_param capture_param = {
-			.sink = pkt
-		};
 
 		/* Create a forwarding request. */
 		int ret = knot_requestor_init(&proxy_data->re, capture,
-		                              &capture_param, qdata->mm);
+		                              pkt, qdata->mm);
 		if (ret != KNOT_EOK) {
 			free(proxy_data);
 			return state; /* Ignore, not enough memory. */

--- a/src/knot/modules/dnsproxy.c
+++ b/src/knot/modules/dnsproxy.c
@@ -107,11 +107,14 @@ static int dnsproxy_fwd(int state, knot_pkt_t *pkt, struct query_data *qdata, vo
 	} else if (layer->defer_fd.fd == 0 || layer->defer_timeout == -1) {
 		// The request is being cancelled.  We need to clean up.
 		layer->defer_fd.fd = 0;
+		proxy_data->re.mm = qdata->mm;
 		knot_request_free(proxy_data->req, proxy_data->re.mm);
 		knot_requestor_clear(&proxy_data->re);
 		free(proxy_data);
 		return KNOT_STATE_DONE;
 	}
+
+	proxy_data->re.mm = qdata->mm;
 
 	/* Forward request. */
 	int ret = knot_requestor_exec_nonblocking(

--- a/src/knot/nameserver/process_query.h
+++ b/src/knot/nameserver/process_query.h
@@ -48,6 +48,7 @@ struct process_query_param {
 	int        socket;
 	const struct sockaddr_storage *remote;
 	unsigned   thread_id;
+	knot_layer_t *layer;
 };
 
 /*! \brief Query processing intermediate data. */

--- a/src/knot/nameserver/update.c
+++ b/src/knot/nameserver/update.c
@@ -219,13 +219,10 @@ static int remote_forward(conf_t *conf, struct knot_request *request, conf_remot
 
 	/* Prepare packet capture layer. */
 	const knot_layer_api_t *capture = query_capture_api();
-	struct capture_param capture_param = {
-		.sink = request->resp
-	};
 
 	/* Create requestor instance. */
 	struct knot_requestor re;
-	ret = knot_requestor_init(&re, capture, &capture_param, NULL);
+	ret = knot_requestor_init(&re, capture, request->resp, NULL);
 	if (ret != KNOT_EOK) {
 		knot_pkt_free(&query);
 		return ret;

--- a/src/knot/query/capture.c
+++ b/src/knot/query/capture.c
@@ -30,7 +30,7 @@ static int finish(knot_layer_t *ctx)
 
 static int begin(knot_layer_t *ctx, void *module_param)
 {
-	ctx->data = module_param; /* struct capture_param */
+	ctx->data = module_param; /* struct knot_pkt */
 	return reset(ctx);
 }
 
@@ -42,9 +42,9 @@ static int prepare_query(knot_layer_t *ctx, knot_pkt_t *pkt)
 static int capture(knot_layer_t *ctx, knot_pkt_t *pkt)
 {
 	assert(pkt && ctx && ctx->data);
-	struct capture_param *param = ctx->data;
+	knot_pkt_t *sink = ctx->data;
 
-	knot_pkt_copy(param->sink, pkt);
+	knot_pkt_copy(sink, pkt);
 
 	return KNOT_STATE_DONE;
 }

--- a/src/knot/query/capture.h
+++ b/src/knot/query/capture.h
@@ -24,9 +24,3 @@
  */
 const knot_layer_api_t *query_capture_api(void);
 
-/*!
- * \brief Processing module parameters.
- */
-struct capture_param {
-	knot_pkt_t *sink; /*!< Container for captured response. */
-};

--- a/src/knot/query/layer.h
+++ b/src/knot/query/layer.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <poll.h>
+
 #include "libknot/packet/pkt.h"
 #include "libknot/mm_ctx.h"
 
@@ -42,6 +44,11 @@ struct knot_layer {
 	knot_mm_t *mm;   /* Processing memory context. */
 	int state;       /* Bitmap of enum knot_layer_state. */
 	void *data;      /* Module specific. */
+	struct pollfd defer_fd;  /* Polling information for deferred query. */
+	int defer_timeout;       /* Polling timeout in seconds. */
+	void *defer_data;        /* Async I/O state info. */
+	struct query_step *step; /* Current query step. */
+	int resume_index;        /* Resume point for deferred functions. */
 	const struct knot_layer_api *api;
 };
 

--- a/src/knot/query/layer.h
+++ b/src/knot/query/layer.h
@@ -119,3 +119,17 @@ int knot_layer_consume(knot_layer_t *ctx, knot_pkt_t *pkt);
  * \return Layer state.
  */
 int knot_layer_produce(knot_layer_t *ctx, knot_pkt_t *pkt);
+
+/*!
+ * \brief Generate output from layer.
+ *
+ * This is the same as knot_layer_produce except that, instead of blocking,
+ * it provides a pollfd structure and timeout value and expects to be
+ * reinvoked when the file descriptor is ready for the specified events.
+ *
+ * \param ctx Layer context.
+ * \param pkt Data packet.
+ *
+ * \return Layer state.
+ */
+int knot_layer_produce_nonblocking(knot_layer_t *ctx, knot_pkt_t *pkt);

--- a/src/knot/query/requestor.c
+++ b/src/knot/query/requestor.c
@@ -372,7 +372,8 @@ static int request_io_nonblocking(struct knot_requestor *req,
 	if (req->layer.state == KNOT_STATE_PRODUCE) {
 
 		/* Process query and send it out. */
-		knot_layer_produce(&req->layer, query);
+		knot_layer_produce_nonblocking(&req->layer, query);
+		if (req->layer.defer_fd.fd) return KNOT_EOK;
 
 		if (req->layer.state == KNOT_STATE_CONSUME) {
 			int ret = request_send_nonblocking(last);

--- a/src/knot/query/requestor.h
+++ b/src/knot/query/requestor.h
@@ -47,6 +47,11 @@ struct knot_request {
 	knot_pkt_t *query;
 	knot_pkt_t *resp;
 	knot_sign_context_t sign;
+
+	/* For non-blocking I/O state */
+	struct iovec iov[2];
+	struct msghdr msg;
+	uint16_t pktsize;
 };
 
 /*!
@@ -107,3 +112,19 @@ void knot_requestor_clear(struct knot_requestor *requestor);
 int knot_requestor_exec(struct knot_requestor *requestor,
                         struct knot_request *request,
                         int timeout_ms);
+
+/*!
+ * \brief Execute a request asynchronously.  This does the same thing as
+ * knot_requestor_exec() except that, instead of blocking, it returns an
+ * event mask and expects to be reinvoked when request->fd becomes ready
+ * for the specified event(s).
+ *
+ * \param requestor  Requestor instance.
+ * \param request    Request instance.
+ *
+ * \return KNOT_EOK, an error or a set of POLL events (see poll(2)).
+ * You can distinguish these three cases because errors are negative,
+ * KNOT_EOK is zero and POLL event masks are positive.
+ */
+int knot_requestor_exec_nonblocking(struct knot_requestor *requestor,
+                                    struct knot_request *request);

--- a/src/knot/server/udp-handler.c
+++ b/src/knot/server/udp-handler.c
@@ -92,7 +92,7 @@ static void udp_handle(udp_context_t *udp, int fd, struct sockaddr_storage *ss,
 
 	/* Process answer. */
 	while (state & (KNOT_STATE_PRODUCE|KNOT_STATE_FAIL)) {
-		state = knot_layer_produce(&udp->layer, udp->ans);
+		state = knot_layer_produce_nonblocking(&udp->layer, udp->ans);
 		if (udp->layer.defer_fd.fd) return;
 	}
 

--- a/src/knot/server/udp-handler.c
+++ b/src/knot/server/udp-handler.c
@@ -436,7 +436,7 @@ static udp_context_t *udp_setup(udp_context_t *udp,
 static void udp_cleanup(udp_context_t *udp) {
 	if (udp->layer.defer_fd.fd) {
 		/* Ask the module to clean up its resources. */
-		udp->layer.defer_fd.fd = 0;
+		udp->layer.defer_fd.fd = -1;
 		_udp_handle(udp, udp->rq);
 	}
 
@@ -454,6 +454,7 @@ static udp_context_t *handle_udp_event(udp_context_t *main_udp,
 		if (_udp_recv(fds->pfd[i].fd, main_udp->rq) <= 0)
 			return main_udp;
 		udp = main_udp;
+		udp->layer.defer_fd.fd = 0;
 	}
 
 	udp->layer.defer_fd.revents = fds->pfd[i].revents;

--- a/src/knot/server/udp-handler.c
+++ b/src/knot/server/udp-handler.c
@@ -584,10 +584,6 @@ int udp_master(dthread_t *thread)
 
 		/* Wait for events. */
 		int events = poll(fds.pfd, fds.n, timeout);
-		if (events <= 0) {
-			if (errno == EINTR) continue;
-			break;
-		}
 
 		/* Process the events.  This must be done in reverse
                  * order so that handle_udp_event() may safely add or

--- a/src/knot/server/udp-handler.c
+++ b/src/knot/server/udp-handler.c
@@ -576,8 +576,18 @@ int udp_master(dthread_t *thread)
 			break;
 		}
 
+		/* Check whether there are pending timeouts.  If so,
+		 * we need to use a positive poll() timeout value. */
+		int timeout = -1;
+		for (int i=0; i < fds.n; ++i) {
+			if (fds.timeout[i] > 0) {
+				timeout = 2;
+				break;
+			}
+		}
+
 		/* Wait for events. */
-		int events = poll(fds.pfd, fds.n, -1);
+		int events = poll(fds.pfd, fds.n, timeout);
 		if (events <= 0) {
 			if (errno == EINTR) continue;
 			break;


### PR DESCRIPTION
BUGGY CODE!  DO NOT MERGE!

This is Dyn's partially successful attempt to enable modules (most notably `dnsproxy`) to perform long-running I/O operations without tying up worker threads.  We no longer intend to use it at Dyn because we achieved our target performance just by increasing the number of worker threads.  We're providing this code mainly in the hope that you may find it useful, or at least interesting.

The basic idea behind the change is that a module can initiate an async I/O operation on a file handle, then instruct its thread's main loop to poll that file handle.  For this to work, each worker thread must be able to manage multiple simultaneous queries.  The implementation only focuses on UDP for now, and it probably breaks TCP handling.  It also causes random stack-smashing segfaults.

We found that this change offers substantially improved QPS with a small number of threads, especially when the remote backend queries have high latency.  The performance was possibly even better than we could achieve by only increasing the thread count, but it's hard to know for sure because our testing was hindered by frequent crashes.

We'll be happy to answer any questions.