### PR TITLE
[base64] use knot namespace for base64 functions

### DIFF
--- a/src/contrib/base64.c
+++ b/src/contrib/base64.c
@@ -81,7 +81,7 @@ static const uint8_t base64_dec[256] = {
 	[ 42] = KO, ['U'] = 20, [128] = KO, [171] = KO, [214] = KO,
 };
 
-int32_t base64_encode(const uint8_t  *in,
+int32_t knot_base64_encode(const uint8_t  *in,
                       const uint32_t in_len,
                       uint8_t        *out,
                       const uint32_t out_len)
@@ -129,7 +129,7 @@ int32_t base64_encode(const uint8_t  *in,
 	return (text - out);
 }
 
-int32_t base64_encode_alloc(const uint8_t  *in,
+int32_t knot_base64_encode_alloc(const uint8_t  *in,
                             const uint32_t in_len,
                             uint8_t        **out)
 {
@@ -151,7 +151,7 @@ int32_t base64_encode_alloc(const uint8_t  *in,
 	}
 
 	// Encode data.
-	int32_t ret = base64_encode(in, in_len, *out, out_len);
+	int32_t ret = knot_base64_encode(in, in_len, *out, out_len);
 	if (ret < 0) {
 		free(*out);
 		*out = NULL;
@@ -160,7 +160,7 @@ int32_t base64_encode_alloc(const uint8_t  *in,
 	return ret;
 }
 
-int32_t base64_decode(const uint8_t  *in,
+int32_t knot_base64_decode(const uint8_t  *in,
                       const uint32_t in_len,
                       uint8_t        *out,
                       const uint32_t out_len)
@@ -243,7 +243,7 @@ int32_t base64_decode(const uint8_t  *in,
 	return (bin - out);
 }
 
-int32_t base64_decode_alloc(const uint8_t  *in,
+int32_t knot_base64_decode_alloc(const uint8_t  *in,
                             const uint32_t in_len,
                             uint8_t        **out)
 {
@@ -262,7 +262,7 @@ int32_t base64_decode_alloc(const uint8_t  *in,
 	}
 
 	// Decode data.
-	int32_t ret = base64_decode(in, in_len, *out, out_len);
+	int32_t ret = knot_base64_decode(in, in_len, *out, out_len);
 	if (ret < 0) {
 		free(*out);
 		*out = NULL;

--- a/src/contrib/base64.h
+++ b/src/contrib/base64.h
@@ -36,7 +36,7 @@
  * \retval >=0		length of output string.
  * \retval KNOT_E*	if error.
  */
-int32_t base64_encode(const uint8_t  *in,
+int32_t knot_base64_encode(const uint8_t  *in,
                       const uint32_t in_len,
                       uint8_t        *out,
                       const uint32_t out_len);
@@ -56,7 +56,7 @@ int32_t base64_encode(const uint8_t  *in,
  * \retval >=0		length of output string.
  * \retval KNOT_E*	if error.
  */
-int32_t base64_encode_alloc(const uint8_t  *in,
+int32_t knot_base64_encode_alloc(const uint8_t  *in,
                             const uint32_t in_len,
                             uint8_t        **out);
 
@@ -75,7 +75,7 @@ int32_t base64_encode_alloc(const uint8_t  *in,
  * \retval >=0		length of output data.
  * \retval KNOT_E*	if error.
  */
-int32_t base64_decode(const uint8_t  *in,
+int32_t knot_base64_decode(const uint8_t  *in,
                       const uint32_t in_len,
                       uint8_t        *out,
                       const uint32_t out_len);
@@ -96,7 +96,7 @@ int32_t base64_decode(const uint8_t  *in,
  * \retval >=0		length of output data.
  * \retval KNOT_E*	if error.
  */
-int32_t base64_decode_alloc(const uint8_t  *in,
+int32_t knot_base64_decode_alloc(const uint8_t  *in,
                             const uint32_t in_len,
                             uint8_t        **out);
 

--- a/src/libdnssec/binary.c
+++ b/src/libdnssec/binary.c
@@ -131,7 +131,7 @@ int dnssec_binary_from_base64(const dnssec_binary_t *base64,
 	}
 
 	uint8_t *data;
-	int32_t size = base64_decode_alloc(base64->data, base64->size, &data);
+	int32_t size = knot_base64_decode_alloc(base64->data, base64->size, &data);
 	if (size < 0) {
 		return DNSSEC_EINVAL;
 	}
@@ -151,7 +151,7 @@ int dnssec_binary_to_base64(const dnssec_binary_t *binary,
 	}
 
 	uint8_t *data;
-	int32_t size = base64_encode_alloc(binary->data, binary->size, &data);
+	int32_t size = knot_base64_encode_alloc(binary->data, binary->size, &data);
 	if (size < 0) {
 		return DNSSEC_EINVAL;
 	}

--- a/src/libknot/rrset-dump.c
+++ b/src/libknot/rrset-dump.c
@@ -1104,7 +1104,7 @@ static void wire_gateway_to_str(rrset_dump_params_t *p)
 		CHECK_PRET
 
 		// Write ipsec key.
-		wire_data_encode_to_str(p, &base64_encode, &base64_encode_alloc);
+		wire_data_encode_to_str(p, &knot_base64_encode, &knot_base64_encode_alloc);
 		CHECK_PRET
 	}
 }
@@ -1301,13 +1301,13 @@ static void dnskey_info(const uint8_t *rdata,
 #define DUMP_TYPE	wire_type_to_str(p); CHECK_RET(p);
 #define DUMP_HEX	wire_data_encode_to_str(p, &hex_encode, \
 				&hex_encode_alloc); CHECK_RET(p);
-#define DUMP_BASE64	wire_data_encode_to_str(p, &base64_encode, \
-				&base64_encode_alloc); CHECK_RET(p);
+#define DUMP_BASE64	wire_data_encode_to_str(p, &knot_base64_encode, \
+				&knot_base64_encode_alloc); CHECK_RET(p);
 #define DUMP_HASH	wire_len_data_encode_to_str(p, &base32hex_encode, \
 				1, false, ""); CHECK_RET(p);
 #define DUMP_SALT	wire_len_data_encode_to_str(p, &hex_encode, \
 				1, false, "-"); CHECK_RET(p);
-#define DUMP_TSIG_DGST	wire_len_data_encode_to_str(p, &base64_encode, \
+#define DUMP_TSIG_DGST	wire_len_data_encode_to_str(p, &knot_base64_encode, \
 				2, true, ""); CHECK_RET(p);
 #define DUMP_TSIG_DATA	wire_len_data_encode_to_str(p, &num48_encode, \
 				2, true, ""); CHECK_RET(p);

--- a/src/libknot/yparser/yptrafo.c
+++ b/src/libknot/yparser/yptrafo.c
@@ -826,7 +826,7 @@ int yp_base64_to_bin(
 	// Reserve some space for data length.
 	wire_ctx_skip(out, sizeof(uint16_t));
 
-	int ret = base64_decode(in->position, YP_LEN, out->position,
+	int ret = knot_base64_decode(in->position, YP_LEN, out->position,
 	                        wire_ctx_available(out));
 	if (ret < 0) {
 		return ret;
@@ -850,7 +850,7 @@ int yp_base64_to_txt(
 	// Read the data length.
 	uint16_t len = wire_ctx_read_u16(in);
 
-	int ret = base64_encode(in->position, len, out->position,
+	int ret = knot_base64_encode(in->position, len, out->position,
 	                        wire_ctx_available(out));
 	if (ret < 0) {
 		return ret;

--- a/src/utils/common/tls.c
+++ b/src/utils/common/tls.c
@@ -331,7 +331,7 @@ static int check_certificates(gnutls_session_t session, const list_t *pins)
 		}
 
 		uint8_t *txt_pin;
-		ret = base64_encode_alloc(cert_pin, sizeof(cert_pin), &txt_pin);
+		ret = knot_base64_encode_alloc(cert_pin, sizeof(cert_pin), &txt_pin);
 		if (ret < 0) {
 			gnutls_x509_crt_deinit(cert);
 			return ret;

--- a/src/utils/kdig/kdig_params.c
+++ b/src/utils/kdig/kdig_params.c
@@ -662,7 +662,7 @@ static int opt_tls_pin(const char *arg, void *query)
 
 	uint8_t pin[64] = { 0 };
 
-	int ret = base64_decode((const uint8_t *)arg, strlen(arg), pin, sizeof(pin));
+	int ret = knot_base64_decode((const uint8_t *)arg, strlen(arg), pin, sizeof(pin));
 	if (ret < 0) {
 		ERR("invalid +tls-pin=%s\n", arg);
 		return ret;

--- a/src/utils/keymgr/functions.c
+++ b/src/utils/keymgr/functions.c
@@ -896,7 +896,7 @@ int keymgr_generate_dnskey(const knot_dname_t *dname, const knot_kasp_key_t *key
 	}
 
 	uint8_t *base64_output = NULL;
-	int len = base64_encode_alloc(pubkey.data, pubkey.size, &base64_output);
+	int len = knot_base64_encode_alloc(pubkey.data, pubkey.size, &base64_output);
 	if (len < 0) {
 		free(name);
 		return len;

--- a/tests/contrib/test_base64.c
+++ b/tests/contrib/test_base64.c
@@ -35,51 +35,51 @@ int main(int argc, char *argv[])
 	uint32_t in_len, ref_len;
 
 	// 0. test invalid input
-	ret = base64_encode(NULL, 0, out, BUF_LEN);
-	is_int(KNOT_EINVAL, ret, "base64_encode: NULL input buffer");
-	ret = base64_encode(in, BUF_LEN, NULL, 0);
-	is_int(KNOT_EINVAL, ret, "base64_encode: NULL output buffer");
-	ret = base64_encode(in, MAX_BIN_DATA_LEN + 1, out, BUF_LEN);
-	is_int(KNOT_ERANGE, ret, "base64_encode: input buffer too large");
-	ret = base64_encode(in, BUF_LEN, out, BUF_LEN);
-	is_int(KNOT_ERANGE, ret, "base64_encode: output buffer too small");
+	ret = knot_base64_encode(NULL, 0, out, BUF_LEN);
+	is_int(KNOT_EINVAL, ret, "knot_base64_encode: NULL input buffer");
+	ret = knot_base64_encode(in, BUF_LEN, NULL, 0);
+	is_int(KNOT_EINVAL, ret, "knot_base64_encode: NULL output buffer");
+	ret = knot_base64_encode(in, MAX_BIN_DATA_LEN + 1, out, BUF_LEN);
+	is_int(KNOT_ERANGE, ret, "knot_base64_encode: input buffer too large");
+	ret = knot_base64_encode(in, BUF_LEN, out, BUF_LEN);
+	is_int(KNOT_ERANGE, ret, "knot_base64_encode: output buffer too small");
 
-	ret = base64_encode_alloc(NULL, 0, &out3);
-	is_int(KNOT_EINVAL, ret, "base64_encode_alloc: NULL input buffer");
-	ret = base64_encode_alloc(in, MAX_BIN_DATA_LEN + 1, &out3);
-	is_int(KNOT_ERANGE, ret, "base64_encode_alloc: input buffer too large");
-	ret = base64_encode_alloc(in, BUF_LEN, NULL);
-	is_int(KNOT_EINVAL, ret, "base64_encode_alloc: NULL output buffer");
+	ret = knot_base64_encode_alloc(NULL, 0, &out3);
+	is_int(KNOT_EINVAL, ret, "knot_base64_encode_alloc: NULL input buffer");
+	ret = knot_base64_encode_alloc(in, MAX_BIN_DATA_LEN + 1, &out3);
+	is_int(KNOT_ERANGE, ret, "knot_base64_encode_alloc: input buffer too large");
+	ret = knot_base64_encode_alloc(in, BUF_LEN, NULL);
+	is_int(KNOT_EINVAL, ret, "knot_base64_encode_alloc: NULL output buffer");
 
-	ret = base64_decode(NULL, 0, out, BUF_LEN);
-	is_int(KNOT_EINVAL, ret, "base64_decode: NULL input buffer");
-	ret = base64_decode(in, BUF_LEN, NULL, 0);
-	is_int(KNOT_EINVAL, ret, "base64_decode: NULL output buffer");
-	ret = base64_decode(in, UINT32_MAX, out, BUF_LEN);
-	is_int(KNOT_ERANGE, ret, "base64_decode: input buffer too large");
-	ret = base64_decode(in, BUF_LEN, out, 0);
-	is_int(KNOT_ERANGE, ret, "base64_decode: output buffer too small");
+	ret = knot_base64_decode(NULL, 0, out, BUF_LEN);
+	is_int(KNOT_EINVAL, ret, "knot_base64_decode: NULL input buffer");
+	ret = knot_base64_decode(in, BUF_LEN, NULL, 0);
+	is_int(KNOT_EINVAL, ret, "knot_base64_decode: NULL output buffer");
+	ret = knot_base64_decode(in, UINT32_MAX, out, BUF_LEN);
+	is_int(KNOT_ERANGE, ret, "knot_base64_decode: input buffer too large");
+	ret = knot_base64_decode(in, BUF_LEN, out, 0);
+	is_int(KNOT_ERANGE, ret, "knot_base64_decode: output buffer too small");
 
-	ret = base64_decode_alloc(NULL, 0, &out3);
-	is_int(KNOT_EINVAL, ret, "base64_decode_alloc: NULL input buffer");
-	ret = base64_decode_alloc(in, UINT32_MAX, &out3);
-	is_int(KNOT_ERANGE, ret, "base64_decode_aloc: input buffer too large");
-	ret = base64_decode_alloc(in, BUF_LEN, NULL);
-	is_int(KNOT_EINVAL, ret, "base64_decode_alloc: NULL output buffer");
+	ret = knot_base64_decode_alloc(NULL, 0, &out3);
+	is_int(KNOT_EINVAL, ret, "knot_base64_decode_alloc: NULL input buffer");
+	ret = knot_base64_decode_alloc(in, UINT32_MAX, &out3);
+	is_int(KNOT_ERANGE, ret, "knot_base64_decode_aloc: input buffer too large");
+	ret = knot_base64_decode_alloc(in, BUF_LEN, NULL);
+	is_int(KNOT_EINVAL, ret, "knot_base64_decode_alloc: NULL output buffer");
 
 	// 1. test vector -> ENC -> DEC
 	strlcpy((char *)in, "", BUF_LEN);
 	in_len = strlen((char *)in);
 	strlcpy((char *)ref, "", BUF_LEN);
 	ref_len = strlen((char *)ref);
-	ret = base64_encode(in, in_len, out, BUF_LEN);
+	ret = knot_base64_encode(in, in_len, out, BUF_LEN);
 	ok(ret == ref_len, "1. test vector - ENC output length");
 	if (ret < 0) {
 		skip("Encode err");
 	} else {
 		ok(memcmp(out, ref, ret) == 0, "1. test vector - ENC output content");
 	}
-	ret = base64_decode(out, ret, out2, BUF_LEN);
+	ret = knot_base64_decode(out, ret, out2, BUF_LEN);
 	ok(ret == in_len, "1. test vector - DEC output length");
 	if (ret < 0) {
 		skip("Decode err");
@@ -92,14 +92,14 @@ int main(int argc, char *argv[])
 	in_len = strlen((char *)in);
 	strlcpy((char *)ref, "Zg==", BUF_LEN);
 	ref_len = strlen((char *)ref);
-	ret = base64_encode(in, in_len, out, BUF_LEN);
+	ret = knot_base64_encode(in, in_len, out, BUF_LEN);
 	ok(ret == ref_len, "2. test vector - ENC output length");
 	if (ret < 0) {
 		skip("Encode err");
 	} else {
 		ok(memcmp(out, ref, ret) == 0, "2. test vector - ENC output content");
 	}
-	ret = base64_decode(out, ret, out2, BUF_LEN);
+	ret = knot_base64_decode(out, ret, out2, BUF_LEN);
 	ok(ret == in_len, "2. test vector - DEC output length");
 	if (ret < 0) {
 		skip("Decode err");
@@ -112,14 +112,14 @@ int main(int argc, char *argv[])
 	in_len = strlen((char *)in);
 	strlcpy((char *)ref, "Zm8=", BUF_LEN);
 	ref_len = strlen((char *)ref);
-	ret = base64_encode(in, in_len, out, BUF_LEN);
+	ret = knot_base64_encode(in, in_len, out, BUF_LEN);
 	ok(ret == ref_len, "3. test vector - ENC output length");
 	if (ret < 0) {
 		skip("Encode err");
 	} else {
 		ok(memcmp(out, ref, ret) == 0, "3. test vector - ENC output content");
 	}
-	ret = base64_decode(out, ret, out2, BUF_LEN);
+	ret = knot_base64_decode(out, ret, out2, BUF_LEN);
 	ok(ret == in_len, "3. test vector - DEC output length");
 	if (ret < 0) {
 		skip("Decode err");
@@ -132,14 +132,14 @@ int main(int argc, char *argv[])
 	in_len = strlen((char *)in);
 	strlcpy((char *)ref, "Zm9v", BUF_LEN);
 	ref_len = strlen((char *)ref);
-	ret = base64_encode(in, in_len, out, BUF_LEN);
+	ret = knot_base64_encode(in, in_len, out, BUF_LEN);
 	ok(ret == ref_len, "4. test vector - ENC output length");
 	if (ret < 0) {
 		skip("Encode err");
 	} else {
 		ok(memcmp(out, ref, ret) == 0, "4. test vector - ENC output content");
 	}
-	ret = base64_decode(out, ret, out2, BUF_LEN);
+	ret = knot_base64_decode(out, ret, out2, BUF_LEN);
 	ok(ret == in_len, "4. test vector - DEC output length");
 	if (ret < 0) {
 		skip("Decode err");
@@ -152,14 +152,14 @@ int main(int argc, char *argv[])
 	in_len = strlen((char *)in);
 	strlcpy((char *)ref, "Zm9vYg==", BUF_LEN);
 	ref_len = strlen((char *)ref);
-	ret = base64_encode(in, in_len, out, BUF_LEN);
+	ret = knot_base64_encode(in, in_len, out, BUF_LEN);
 	ok(ret == ref_len, "5. test vector - ENC output length");
 	if (ret < 0) {
 		skip("Encode err");
 	} else {
 		ok(memcmp(out, ref, ret) == 0, "5. test vector - ENC output content");
 	}
-	ret = base64_decode(out, ret, out2, BUF_LEN);
+	ret = knot_base64_decode(out, ret, out2, BUF_LEN);
 	ok(ret == in_len, "5. test vector - DEC output length");
 	if (ret < 0) {
 		skip("Decode err");
@@ -172,14 +172,14 @@ int main(int argc, char *argv[])
 	in_len = strlen((char *)in);
 	strlcpy((char *)ref, "Zm9vYmE=", BUF_LEN);
 	ref_len = strlen((char *)ref);
-	ret = base64_encode(in, in_len, out, BUF_LEN);
+	ret = knot_base64_encode(in, in_len, out, BUF_LEN);
 	ok(ret == ref_len, "6. test vector - ENC output length");
 	if (ret < 0) {
 		skip("Encode err");
 	} else {
 		ok(memcmp(out, ref, ret) == 0, "6. test vector - ENC output content");
 	}
-	ret = base64_decode(out, ret, out2, BUF_LEN);
+	ret = knot_base64_decode(out, ret, out2, BUF_LEN);
 	ok(ret == in_len, "6. test vector - DEC output length");
 	if (ret < 0) {
 		skip("Decode err");
@@ -192,14 +192,14 @@ int main(int argc, char *argv[])
 	in_len = strlen((char *)in);
 	strlcpy((char *)ref, "Zm9vYmFy", BUF_LEN);
 	ref_len = strlen((char *)ref);
-	ret = base64_encode(in, in_len, out, BUF_LEN);
+	ret = knot_base64_encode(in, in_len, out, BUF_LEN);
 	ok(ret == ref_len, "7. test vector - ENC output length");
 	if (ret < 0) {
 		skip("Encode err");
 	} else {
 		ok(memcmp(out, ref, ret) == 0, "7. test vector - ENC output content");
 	}
-	ret = base64_decode(out, ret, out2, BUF_LEN);
+	ret = knot_base64_decode(out, ret, out2, BUF_LEN);
 	ok(ret == in_len, "7. test vector - DEC output length");
 	if (ret < 0) {
 		skip("Decode err");
@@ -208,29 +208,29 @@ int main(int argc, char *argv[])
 	}
 
 	// Bad paddings
-	ret = base64_decode((uint8_t *)"A===", 4, out, BUF_LEN);
+	ret = knot_base64_decode((uint8_t *)"A===", 4, out, BUF_LEN);
 	ok(ret == KNOT_BASE64_ECHAR, "Bad padding length 3");
-	ret = base64_decode((uint8_t *)"====", 4, out, BUF_LEN);
+	ret = knot_base64_decode((uint8_t *)"====", 4, out, BUF_LEN);
 	ok(ret == KNOT_BASE64_ECHAR, "Bad padding length 4");
-	ret = base64_decode((uint8_t *)"AA=A", 4, out, BUF_LEN);
+	ret = knot_base64_decode((uint8_t *)"AA=A", 4, out, BUF_LEN);
 	ok(ret == KNOT_BASE64_ECHAR, "Bad padding character on position 2");
-	ret = base64_decode((uint8_t *)"Zg==Zg==", 8, out, BUF_LEN);
+	ret = knot_base64_decode((uint8_t *)"Zg==Zg==", 8, out, BUF_LEN);
 	ok(ret == KNOT_BASE64_ECHAR, "Two quartets with padding");
 
 	// Bad data length
-	ret = base64_decode((uint8_t *)"A", 1, out, BUF_LEN);
+	ret = knot_base64_decode((uint8_t *)"A", 1, out, BUF_LEN);
 	ok(ret == KNOT_BASE64_ESIZE, "Bad data length 1");
-	ret = base64_decode((uint8_t *)"AA", 2, out, BUF_LEN);
+	ret = knot_base64_decode((uint8_t *)"AA", 2, out, BUF_LEN);
 	ok(ret == KNOT_BASE64_ESIZE, "Bad data length 2");
-	ret = base64_decode((uint8_t *)"AAA", 3, out, BUF_LEN);
+	ret = knot_base64_decode((uint8_t *)"AAA", 3, out, BUF_LEN);
 	ok(ret == KNOT_BASE64_ESIZE, "Bad data length 3");
-	ret = base64_decode((uint8_t *)"AAAAA", 5, out, BUF_LEN);
+	ret = knot_base64_decode((uint8_t *)"AAAAA", 5, out, BUF_LEN);
 	ok(ret == KNOT_BASE64_ESIZE, "Bad data length 5");
 
 	// Bad data character
-	ret = base64_decode((uint8_t *)"AAA$", 4, out, BUF_LEN);
+	ret = knot_base64_decode((uint8_t *)"AAA$", 4, out, BUF_LEN);
 	ok(ret == KNOT_BASE64_ECHAR, "Bad data character dollar");
-	ret = base64_decode((uint8_t *)"AAA ", 4, out, BUF_LEN);
+	ret = knot_base64_decode((uint8_t *)"AAA ", 4, out, BUF_LEN);
 	ok(ret == KNOT_BASE64_ECHAR, "Bad data character space");
 
 	return 0;


### PR DESCRIPTION
both knot and gnutls (at least until [3.4](https://gitlab.com/gnutls/gnutls/-/blob/gnutls_3_4_x/gl/base64.c)) define their own base64_{en,de}code{_alloc}.

When linking with ODR violation detection, it fails with:
```
ld.lld: error: duplicate symbol: base64_encode
stderr: ld.lld: error: duplicate symbol: base64_encode
```

This diff put the base64* functions under `knot_` namespace to avoid the
conflict.