### PR TITLE
process query: always log ACL check 

### DIFF
--- a/src/knot/zone/zone.h
+++ b/src/knot/zone/zone.h
@@ -78,7 +78,7 @@ typedef struct zone
 	/*! \brief Control update context. */
 	struct zone_update *control_update;
 
-	/*! \brief Ensue one COW tramsaction on zone's trees at a time. */
+	/*! \brief Ensue one COW transaction on zone's trees at a time. */
 	knot_sem_t cow_lock;
 
 	/*! \brief Ptr to journal DB (in struct server) */


### PR DESCRIPTION
Instead of only logging when access was not granted, also log when it was.
I'm interested in having this information for audit purposes.

The downside is that the memory allocation, parsing from the various structs and subsequent freeing _probably_ always takes place with this. Not sure how relevant that is, performance wise.


The other commit is a simple typo fix, which I noticed when reading through the code.