### PR TITLE
serial policy: streamlined

### DIFF
--- a/src/knot/events/handlers/load.c
+++ b/src/knot/events/handlers/load.c
@@ -118,7 +118,7 @@ int event_load(conf_t *conf, zone_t *zone)
 		if (zf_conts != NULL && zf_from == ZONEFILE_LOAD_DIFSE && relevant != NULL) {
 			uint32_t serial = zone_contents_serial(relevant);
 			conf_val_t policy = conf_zone_get(conf, C_SERIAL_POLICY, zone->name);
-			uint32_t set = serial_next(serial, conf_opt(&policy));
+			uint32_t set = serial_next(serial, conf_opt(&policy), 1);
 			zone_contents_set_soa_serial(zf_conts, set);
 			log_zone_info(zone->name, "zone file parsed, serial corrected %u -> %u",
 			              zone->zonefile.serial, set);
@@ -145,7 +145,7 @@ int event_load(conf_t *conf, zone_t *zone)
 	}
 	if (zone->cat_members != NULL && !old_contents_exist) {
 		uint32_t serial = journal_conts == NULL ? 1 : zone_contents_serial(journal_conts);
-		serial = serial_next(serial, SERIAL_POLICY_UNIXTIME); // unixtime hardcoded
+		serial = serial_next(serial, SERIAL_POLICY_UNIXTIME, 1); // unixtime hardcoded
 		zf_conts = catalog_update_to_zone(zone->cat_members, zone->name, serial);
 		if (zf_conts == NULL) {
 			ret = zone->cat_members->error == KNOT_EOK ? KNOT_ENOMEM : zone->cat_members->error;

--- a/src/knot/updates/zone-update.c
+++ b/src/knot/updates/zone-update.c
@@ -643,7 +643,7 @@ static int set_new_soa(zone_update_t *update, unsigned serial_policy)
 	}
 
 	uint32_t old_serial = knot_soa_serial(soa_cpy->rrs.rdata);
-	uint32_t new_serial = serial_next(old_serial, serial_policy);
+	uint32_t new_serial = serial_next(old_serial, serial_policy, 1);
 	if (serial_compare(old_serial, new_serial) != SERIAL_LOWER) {
 		log_zone_warning(update->zone->name, "updated SOA serial is lower "
 		                 "than current, serial %u -> %u",

--- a/src/knot/zone/serial.c
+++ b/src/knot/zone/serial.c
@@ -35,62 +35,40 @@ serial_cmp_result_t serial_compare(uint32_t s1, uint32_t s2)
 	return diffbrief2result[diffbrief];
 }
 
-static uint32_t serial_next_date(uint32_t current)
+static uint32_t serial_dateserial(uint32_t current)
 {
-	uint32_t next = current + 1;
-
 	struct tm now;
 	time_t current_time = time(NULL);
 	struct tm *gmtime_result = gmtime_r(&current_time, &now);
 	if (gmtime_result == NULL) {
-		return next;
+		return current;
 	}
-
-	uint32_t yyyyMMdd00 = (1900 + now.tm_year) * 1000000 +
-	                      (   1 + now.tm_mon ) *   10000 +
-	                      (       now.tm_mday) *     100;
-
-	if (next < yyyyMMdd00) {
-		next = yyyyMMdd00;
-	}
-
-	return next;
+	return (1900 + now.tm_year) * 1000000 +
+	       (   1 + now.tm_mon ) *   10000 +
+	       (       now.tm_mday) *     100;
 }
 
-uint32_t serial_next(uint32_t current, int policy)
+uint32_t serial_next(uint32_t current, int policy, uint32_t must_increment)
 {
-	uint32_t candidate;
+	uint32_t minimum;
 	switch (policy) {
 	case SERIAL_POLICY_INCREMENT:
-		return current + 1;
+		minimum = current;
+		break;
 	case SERIAL_POLICY_UNIXTIME:
-		candidate = time(NULL);
-		if (serial_compare(candidate, current) != SERIAL_GREATER) {
-			return current + 1;
-		} else {
-			return candidate;
-		}
+		minimum = time(NULL);
+		break;
 	case SERIAL_POLICY_DATESERIAL:
-		return serial_next_date(current);
+		minimum = serial_dateserial(current);
+		break;
 	default:
 		assert(0);
 		return 0;
 	}
-}
-
-bool serial_must_increment(uint32_t current, int policy)
-{
-	switch (policy) {
-	case SERIAL_POLICY_INCREMENT:
-		return false;
-	case SERIAL_POLICY_UNIXTIME:
-		return true;
-	case SERIAL_POLICY_DATESERIAL:
-		// Trim off the serial parts from YYYYMMDDnn.
-		return (current / 100) < (serial_next_date(current) / 100);
-	default:
-		assert(0);
-		return false;
+	if (serial_compare(minimum, current) != SERIAL_GREATER) {
+		return current + must_increment;
+	} else {
+		return minimum;
 	}
 }
 

--- a/src/knot/zone/serial.h
+++ b/src/knot/zone/serial.h
@@ -44,26 +44,17 @@ inline static bool serial_equal(uint32_t a, uint32_t b)
 }
 
 /*!
- * \brief Get next serial for given serial update policy.
+ * \brief Get (next) serial for given serial update policy.
  *
  * \param current  Current SOA serial.
  * \param policy   SERIAL_POLICY_INCREMENT, SERIAL_POLICY_UNIXTIME or
  *                 SERIAL_POLICY_DATESERIAL.
+ * \param must_increment The minimum difference to the current value.
+ *                 0 only ensures policy; 1 also increments.
  *
  * \return New serial.
  */
-uint32_t serial_next(uint32_t current, int policy);
-
-/*!
- * \brief Check if the current serial must be incremented to match local policy.
- *
- * \param current  Current SOA serial.
- * \param policy   SERIAL_POLICY_INCREMENT, SERIAL_POLICY_UNIXTIME or
- *                 SERIAL_POLICY_DATESERIAL.
- *
- * \return True if update is necessary.
- */
-bool serial_must_increment(uint32_t current, int policy);
+uint32_t serial_next(uint32_t current, int policy, uint32_t must_increment);
 
 typedef struct {
 	uint32_t serial;


### PR DESCRIPTION
Simplify serial number handling, e.g. by eliminating `serial_must_increment()` (which unnecessarily forced increment for `unixtime`, as I just noticed).

See https://gitlab.nic.cz/knot/knot-dns/-/issues/717