### PR TITLE
knot: fix crash caused by double free

### DIFF
--- a/src/knot/nameserver/query_module.c
+++ b/src/knot/nameserver/query_module.c
@@ -729,6 +729,7 @@ int knotd_mod_dnssec_init(knotd_mod_t *mod)
 	                           conf_bool(&conf) ? NULL : mod->id);
 	if (ret != KNOT_EOK) {
 		free(mod->dnssec);
+		mod->dnssec = NULL;
 		return ret;
 	}
 


### PR DESCRIPTION
How to reproduce:

1. Enable DNSSEC and onlinesign
2. Run knotd and it will create the keys folder.(For example, /usr/local/var/lib/knot/keys)
3. Delete the folder
4. Run "knotc reload"

The crash was caused by double free.  After deleting the keys folder and run reload, it would cause mod->api->load(mod) return -2 then to free mod->dnssec in query_module_close(). But it has been freed in knotd_mod_dnssec_init

 
