### PR TITLE
Add support for building on Cygwin and MSYS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,7 @@ Makefile.in
 /.project
 /.cproject
 /.settings/
+
+# cygwin
+*.exe
+*.exe.manifest

--- a/configure.ac
+++ b/configure.ac
@@ -61,6 +61,12 @@ AC_PROG_INSTALL
 # Initialize libtool
 LT_INIT
 
+# Build DLLs on Cygwin/MSYS2
+AS_CASE([$host],
+  [*-cygwin* | *-msys*], [LT_NO_UNDEFINED="-no-undefined"]
+)
+AC_SUBST(LT_NO_UNDEFINED)
+
 # Use pkg-config
 PKG_PROG_PKG_CONFIG
 m4_ifdef([PKG_INSTALLDIR], [PKG_INSTALLDIR], [AC_SUBST([pkgconfigdir], ['${libdir}/pkgconfig'])])

--- a/m4/knot-lib-version.m4
+++ b/m4/knot-lib-version.m4
@@ -4,10 +4,13 @@
 
 AC_DEFUN([KNOT_LIB_VERSION],
 [
+  m4_define([LIBNAME], patsubst($1, [^lib], []))dnl
   AC_SUBST([$1_VERSION_INFO], ["-version-info $2:$3:$4"])
   AC_SUBST([$1_SOVERSION],    ["$2"])
   AS_CASE([$host_os],
      [darwin*], [AC_SUBST([$1_SONAME], ["$1.$2.dylib"])],
+     [cygwin*], [AC_SUBST([$1_SONAME], [m4_join([], ["cyg], LIBNAME, [-$2.dll"])])],
+     [msys*],   [AC_SUBST([$1_SONAME], [m4_join([], ["msys-], LIBNAME, [-$2.dll"])])],
      [*],       [AC_SUBST([$1_SONAME], ["$1.so.$2"])]
   )
 ])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -6,6 +6,8 @@ AM_CPPFLAGS = \
 	-DMODULE_DIR='"${module_dir}"'		\
 	-DMODULE_INSTDIR='"${module_instdir}"'
 
+AM_LDFLAGS = $(LT_NO_UNDEFINED)
+
 EXTRA_DIST =
 CLEANFILES =
 BUILT_SOURCES =

--- a/src/libknot/endian.h
+++ b/src/libknot/endian.h
@@ -30,7 +30,7 @@
 #       include <endian.h>
 #elif defined(__FreeBSD__) || defined(__NetBSD__)
 #       include <sys/endian.h>
-#elif defined(__OpenBSD__) || defined(__sun)
+#elif defined(__OpenBSD__) || defined(__sun) || defined(__CYGWIN__)
 #       include <endian.h>
 #elif defined(__APPLE__)
 #       include <libkern/OSByteOrder.h>


### PR DESCRIPTION
At the moment you have to `configure` with `--disable-daemon` because it seems some of the IPV6 calls do not exist in Cygwin\MSYS2.  This is ok for me because I just need the libs to build `knot-resolver`.