### PR TITLE
Invoke rcu_register_thread() before its first call to rcu_read_lock()

### DIFF
--- a/src/knot/common/stats.c
+++ b/src/knot/common/stats.c
@@ -247,6 +247,7 @@ static void dump_stats(server_t *server)
 
 static void *dumper(void *data)
 {
+	rcu_register_thread();
 	while (true) {
 		assert(stats.timer > 0);
 		sleep(stats.timer);
@@ -257,7 +258,7 @@ static void *dumper(void *data)
 		rcu_read_unlock();
 		pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
 	}
-
+	rcu_unregister_thread();
 	return NULL;
 }
 


### PR DESCRIPTION
Each thread must invoke rcu_register_thread() before its first call to rcu_read_lock(). 