### PR TITLE
tls: fix connection issues with some servers

### DIFF
--- a/src/utils/common/netio.c
+++ b/src/utils/common/netio.c
@@ -523,7 +523,7 @@ int net_connect(net_t *net)
 			{
 				// Establish TLS connection.
 				ret = tls_ctx_setup_remote_endpoint(&net->tls, &dot_alpn, 1,
-				        KNOT_TLS_PRIORITIES, net_get_remote(net));
+				        NULL, net_get_remote(net));
 				if (ret != 0) {
 					net_close(net);
 					return ret;


### PR DESCRIPTION
Before:
$ kdig +short +tls dns.google @1.12.12.12
;; WARNING: TLS, handshake failed (A TLS fatal alert has been received.) ;; ERROR: failed to query server 1.12.12.12@853(TCP)

After:
$ kdig +short +tls dns.google @1.12.12.12
8.8.4.4
8.8.8.8

Fixes: bd75c1fe3 (tls: unification of TLS priority settings, 2024-04-26)