### PR TITLE
Fix build on macOS < 10.11

### DIFF
--- a/src/contrib/net.c
+++ b/src/contrib/net.c
@@ -6,12 +6,12 @@
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <sys/socket.h>
 #include <sys/types.h>   // OpenBSD
 #include <netinet/tcp.h> // TCP_FASTOPEN
 #include <netinet/in.h>
 #include <poll.h>
 #include <stdbool.h>
-#include <sys/socket.h>
 #include <sys/uio.h>
 #include <unistd.h>
 

--- a/src/contrib/net.c
+++ b/src/contrib/net.c
@@ -21,6 +21,10 @@
 #include "contrib/sockaddr.h"
 #include "contrib/time.h"
 
+#ifdef __APPLE__
+#include <AvailabilityMacros.h>
+#endif
+
 /*!
  * \brief Enable socket option.
  */
@@ -238,7 +242,7 @@ static int tfo_connect(int sock, const struct sockaddr_storage *addr)
 	return KNOT_EOK;
 #elif defined(__FreeBSD__)
 	return sockopt_enable(sock, IPPROTO_TCP, TCP_FASTOPEN);
-#elif defined(__APPLE__)
+#elif defined(__APPLE__) && (MAC_OS_X_VERSION_MIN_REQUIRED >= 101100)
 	/* Connection is performed lazily when first data is sent. */
 	sa_endpoints_t ep = {
 		.sae_dstaddr = (const struct sockaddr *)addr,

--- a/src/knot/server/server.c
+++ b/src/knot/server/server.c
@@ -192,7 +192,11 @@ static bool enable_pktinfo(int sock, int family)
 		break;
 	case AF_INET6:
 		level = IPPROTO_IPV6;
+#if defined(IPV6_RECVPKTINFO)
 		option = IPV6_RECVPKTINFO; /* Multiplatform */
+#else
+		option = IPV6_PKTINFO;
+#endif
 		break;
 	default:
 		assert(0);

--- a/src/utils/common/netio.c
+++ b/src/utils/common/netio.c
@@ -17,6 +17,10 @@
 #include <sys/uio.h>
 #endif
 
+#ifdef __APPLE__
+#include <AvailabilityMacros.h>
+#endif
+
 #include "utils/common/netio.h"
 #include "utils/common/msg.h"
 #include "utils/common/tls.h"
@@ -347,7 +351,7 @@ static int fastopen_connect(int sockfd, const struct addrinfo *srv)
 #if defined( __FreeBSD__)
 	const int enable = 1;
 	return setsockopt(sockfd, IPPROTO_TCP, TCP_FASTOPEN, &enable, sizeof(enable));
-#elif defined(__APPLE__)
+#elif defined(__APPLE__) && (MAC_OS_X_VERSION_MIN_REQUIRED >= 101100)
 	// connection is performed lazily when first data are sent
 	struct sa_endpoints ep = {0};
 	ep.sae_dstaddr = srv->ai_addr;


### PR DESCRIPTION
Implementation used for Apple here can only work for 10.11+: https://developer.apple.com/documentation/kernel/sa_endpoints_t
Drop to fallback for older versions.