### PR TITLE
Avoid label collisions and duplicate metrics in knot-exporter

### DIFF
--- a/python/knot_exporter/knot_exporter/knot_exporter.py
+++ b/python/knot_exporter/knot_exporter/knot_exporter.py
@@ -84,6 +84,12 @@ class KnotCollector(object):
             for pid, usage in memory_usage().items():
                 metric_families_append('knot_memory_usage', ['section', 'type'], ['server', str(pid)], usage)
 
+        # Pre-create metrics to avoid future label collisions
+        forced_metrics_format = ['knot_request_protocol', 'knot_server_operation', 'knot_request_bytes', 'knot_response_bytes', 'knot_response_code']
+        for metric  in forced_metrics_format:
+            metric_families[metric] = GaugeMetricFamily(metric, '', labels=['zone', 'section', 'type'])
+            metric_families[metric + '_total'] = CounterMetricFamily(metric + '_total', '', labels=['zone', 'section', 'type'])
+
         if self.collect_stats:
             ctl.send_block(cmd="stats", flags="")
             global_stats = ctl.receive_stats()


### PR DESCRIPTION
When metric families were instantiated dynamically, multiple families with the same metric name could be registered under slightly different labels.  
This is not allowed by the [Prometheus client libraries rules](https://prometheus.io/docs/instrumenting/writing_clientlibs/#labels).

As a result, the Prometheus exposition output contained duplicated metrics and inconsistent label content, leading to unreliable scraping results.

This fix pre-creates a fixed set of metric families with a known set of labels, ensuring stability, preventing duplication, and fixing the label content issue.

Example of the issue:
```
# HELP knot_request_protocol
# TYPE knot_request_protocol gauge
knot_request_protocol{section="mod-stats",type="udp4"} 590119.0
knot_request_protocol{section="mod-stats",type="tcp4"} 345.0
knot_request_protocol{section="mod-stats",type="udp6"} 260776.0
knot_request_protocol{section="mod-stats",type="tcp6"} 387.0
knot_request_protocol{section="110.11.141.in-addr.arpa.",type="mod-stats"} 53365.0
knot_request_protocol{section="110.11.141.in-addr.arpa.",type="mod-stats"} 15.0
knot_request_protocol{section="110.11.141.in-addr.arpa.",type="mod-stats"} 27390.0
knot_request_protocol{section="110.11.141.in-addr.arpa.",type="mod-stats"} 12.0
[...]
```

After fix:
```
# HELP knot_request_protocol
# TYPE knot_request_protocol gauge
knot_request_protocol{section="udp4",zone="mod-stats"} 599416.0
knot_request_protocol{section="tcp4",zone="mod-stats"} 350.0
knot_request_protocol{section="udp6",zone="mod-stats"} 266111.0
knot_request_protocol{section="tcp6",zone="mod-stats"} 391.0
knot_request_protocol{section="mod-stats",type="udp4",zone="110.11.141.in-addr.arpa."} 53556.0
knot_request_protocol{section="mod-stats",type="tcp4",zone="110.11.141.in-addr.arpa."} 15.0
knot_request_protocol{section="mod-stats",type="udp6",zone="110.11.141.in-addr.arpa."} 27432.0
knot_request_protocol{section="mod-stats",type="tcp6",zone="110.11.141.in-addr.arpa."} 12.0
```