### PR TITLE
distro: add sysusers.d file

### DIFF
--- a/distro/common/knot.sysusers.conf
+++ b/distro/common/knot.sysusers.conf
@@ -1,0 +1,1 @@
+u! knot - - /var/lib/knot


### PR DESCRIPTION
sysusers.d config files allows a package to use declarative configuration instead of manually written maintainer scripts.
The distro/common/knot.service unit file uses User=knot and Group=knot so the user/group need to be created before it can be started, and this takes care of it automatically.
This also allows image-based systems to be created with /usr/ only, and also allows for factory resetting a system and recreating /etc/ on boot.

https://www.freedesktop.org/software/systemd/man/latest/sysusers.d.html