### PR TITLE
Fix confdb to not become unresponsive on broken commit related to an existing config relation

### DIFF
--- a/src/knot/ctl/commands.c
+++ b/src/knot/ctl/commands.c
@@ -2226,6 +2226,7 @@ static int ctl_conf_txn(ctl_args_t *args, ctl_cmd_t cmd)
 		if (ret != KNOT_EOK) {
 			// A semantic error is already sent by the check function.
 			if (io.error.code != KNOT_EOK) {
+				(void)conf_io_abort(false);
 				return KNOT_EOK;
 			}
 			// No transaction abort!


### PR DESCRIPTION
## Problem description

When a configuration commit fails due to an invalid reference, the configuration
transaction is not properly released. This leaves `confdb` in a locked state,
causing subsequent configuration commands to fail with transaction-related errors.

In this state, it is no longer possible to start a new configuration transaction
or abort the previous one, effectively making configuration management unusable
until the daemon is restarted.

---

## Steps to reproduce

1. Start with a valid configuration containing a key referenced by an ACL:
   ```key.id = cli-key.
    key[cli-key.].algorithm = hmac-sha256
    key[cli-key.].secret = cXdlcnR5dWlvcGFzZGZnaGpsenhjdmJubQ==
    acl.id = cli-acl
    acl[cli-acl].address = 10.0.0.1
    acl[cli-acl].key = cli-key.
    acl[cli-acl].action = transfer
   ```

2. Begin a configuration transaction:
   ```sh
   knotc conf-begin
   ```

3. Remove a key that is still referenced:
   ```sh
   knotc conf-unset 'key[cli-key.]'
   ```

4. Attempt to commit the configuration:
   ```sh
   knotc conf-commit
   ```
   Result:
   ```
   error: (invalid reference) acl[cli-acl].key = cli-key.
   ```

5. Try to start or abort the transaction:
   ```sh
   knotc conf-begin
   ```
   ```
   error: (too many transactions)
   ```

   ```sh
   knotc conf-abort
   ```
   ```
   error: (requested resource is busy)
   ```

---

## Proposed fix

I have provided some example fix that works on my side, I'm not sure if this is the best solution, but it seems a working one. 
