### PR TITLE
Add support for EDE code 33 (Negative Trust Anchor)

### DIFF
--- a/src/libknot/codes.c
+++ b/src/libknot/codes.c
@@ -82,6 +82,7 @@ const knot_lookup_t knot_edns_ede_names[] = {
 	{ KNOT_EDNS_EDE_NONCONF_POLICY,   "Unable to conform to policy" },
 	{ KNOT_EDNS_EDE_SYNTHESIZED,      "Synthesized" },
 	{ KNOT_EDNS_EDE_INV_QTYPE,        "Invalid Query Type" },
+	{ KNOT_EDNS_EDE_NTA,              "Negative Trust Anchor" },
 	{ 0, NULL }
 };
 

--- a/src/libknot/consts.h
+++ b/src/libknot/consts.h
@@ -124,6 +124,7 @@ typedef enum {
 	KNOT_EDNS_EDE_NONCONF_POLICY   = 28,
 	KNOT_EDNS_EDE_SYNTHESIZED      = 29,
 	KNOT_EDNS_EDE_INV_QTYPE        = 30,
+	KNOT_EDNS_EDE_NTA              = 33,
 } knot_edns_ede_t;
 
 /*!


### PR DESCRIPTION
Let users know what a resolver returned an insecure answer, when an NTA is in effect.

IANA has already assigned an Extended DNS Error INFO-CODE 33 "Negative Trust Anchor"

Link: https://datatracker.ietf.org/doc/draft-farrokhi-dnsop-ede-nta/